### PR TITLE
Fix : WithAuth - 권한분기 로직 변경

### DIFF
--- a/src/components/commons/hocs/WithAuth.tsx
+++ b/src/components/commons/hocs/WithAuth.tsx
@@ -7,12 +7,21 @@ import { FETCH_USER_LOGGED_IN } from "../../units/accounts/login /Login.queries"
 export const WithAuth = (Component) => (props) => {
   const router = useRouter();
   const { accessToken } = useContext(GlobalContext);
-  const { data } = useQuery(FETCH_USER_LOGGED_IN);
 
+  const { data } = useQuery(FETCH_USER_LOGGED_IN);
+  // refreshToken 만 하면, 로그인안된 유저도 localStorage에 refreshToken: true 가 남아있을 때
+  // 접근가능해서 안되고,
+  // fetchUserLoggedIn 데이터로 한번 더 거르면, 데이터를 받아오는 속도때문에 항상 실행됨
+  // 그런데 생각해보니 애초에 한번 로그인하면 로그아웃하지 않는 이상 refreshToken이 살아있으면 계속 자동 로그인됨
+  // 이건 백엔드 잘못. 우린 이대로 간다. 로그아웃 생활화하자.
   useEffect(() => {
-    if (!localStorage.getItem("refreshToken") || !data) {
+    if (!localStorage.getItem("refreshToken")) {
       alert("Posh에 입장해 주세요");
       router.push("/posh/accounts/login");
+      if (!data) {
+        alert("Posh에 입장해 주세요");
+        router.push("/posh/accounts/login");
+      }
     }
   }, [accessToken, data]);
   return <Component {...props} />;

--- a/src/components/units/accounts/login /Login.container.tsx
+++ b/src/components/units/accounts/login /Login.container.tsx
@@ -46,11 +46,11 @@ export default function Login() {
         },
       });
 
-      setAccessToken(result.data?.loginUser.accessToken);
+      setAccessToken(result.data?.loginUserExample.accessToken);
       localStorage.setItem("refreshToken", "true");
 
       router.push("../home/");
-      console.log(result.data?.loginUser.accessToken);
+      // console.log(result.data?.loginUser.accessToken);
 
       alert("Posh Posh");
     }

--- a/src/components/units/accounts/login /Login.queries.ts
+++ b/src/components/units/accounts/login /Login.queries.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const LOGIN_USER = gql`
   mutation loginUser($email: String!, $password: String!) {
-    loginUser(email: $email, password: $password) {
+    loginUserExample(email: $email, password: $password) {
       accessToken
     }
   }


### PR DESCRIPTION
  // refreshToken 만 하면, 로그인안된 유저도 localStorage에 refreshToken: true 가 남아있을 때
  // 접근가능해서 안되고,
  // fetchUserLoggedIn 데이터로 한번 더 거르면, 데이터를 받아오는 속도때문에 항상 실행됨
  // 그런데 생각해보니 애초에 한번 로그인하면 로그아웃하지 않는 이상 refreshToken이 살아있으면 계속 자동 로그인됨
  // 이건 백엔드 잘못. 우린 이대로 간다. 로그아웃 생활화하자.