### PR TITLE
[feature-chat-update] 메세지 입력 useRef 사용(렌더횟수줄이기)

### DIFF
--- a/src/components/units/products/chatRoom/chatRoom.container.tsx
+++ b/src/components/units/products/chatRoom/chatRoom.container.tsx
@@ -47,9 +47,9 @@ export default function ChatRoom() {
   const productName = item?.fetchUseditem.name;
   const productPrice = item?.fetchUseditem.price;
   const roomId = `${router.query.poshId}${router.query.roomId}`;
-  const inputRef = useRef();
+  const inputRef = useRef<HTMLInputElement | any>(null);
 
-  async function saveMessage(event: any) {
+  async function saveMessage() {
     try {
       await addDoc(collection(getFirestore(), `chatDB`), {
         roomId: roomId,
@@ -107,15 +107,21 @@ export default function ChatRoom() {
     router.push(`/posh/products/${router.query.poshId}/seller`);
   }
 
+  function enterKey() {
+    if (window.event.keyCode == 13) {
+      saveMessage();
+    }
+  }
+
   useEffect(() => {
     loadMessages();
   }, [roomId, name]);
-  console.log("렌더", messages);
 
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
 
+  console.log("렌더", messages);
   return (
     <ChatRoomUI
       onChangemessage={onChangemessage}
@@ -129,6 +135,7 @@ export default function ChatRoom() {
       inputRef={inputRef}
       myId={myId}
       onClickToProfile={onClickToProfile}
+      enterKey={enterKey}
     />
   );
 }

--- a/src/components/units/products/chatRoom/chatRoom.container.tsx
+++ b/src/components/units/products/chatRoom/chatRoom.container.tsx
@@ -103,6 +103,10 @@ export default function ChatRoom() {
     router.push(`/posh/products/${router.query.poshId}`);
   }
 
+  function onClickToProfile() {
+    router.push(`/posh/products/${router.query.poshId}/seller`);
+  }
+
   useEffect(() => {
     loadMessages();
   }, [roomId, name]);
@@ -124,6 +128,7 @@ export default function ChatRoom() {
       messages={messages}
       inputRef={inputRef}
       myId={myId}
+      onClickToProfile={onClickToProfile}
     />
   );
 }

--- a/src/components/units/products/chatRoom/chatRoom.presenter.tsx
+++ b/src/components/units/products/chatRoom/chatRoom.presenter.tsx
@@ -35,7 +35,10 @@ export default function ChatRoomUI(props: any) {
           <>
             {props.myId !== el.writer[1] ? (
               <GetMessageWrapper key={el.timestamp}>
-                <ProfileImg src={el.profilePicUrl} />
+                <ProfileImg
+                  src={el.profilePicUrl}
+                  onClick={props.onClickToProfile}
+                />
                 <MessageInfo>
                   <Name>{el.writer[0]}</Name>
                   <GetMessageBox>{el.text}</GetMessageBox>

--- a/src/components/units/products/chatRoom/chatRoom.presenter.tsx
+++ b/src/components/units/products/chatRoom/chatRoom.presenter.tsx
@@ -16,6 +16,7 @@ import {
   ProductPrice,
   MessageInfo,
   MyMessageWrapper,
+  NewDate,
 } from "./chatRoom.styles";
 
 export default function ChatRoomUI(props: any) {
@@ -31,10 +32,12 @@ export default function ChatRoomUI(props: any) {
         </ProductInfo>
       </ProductWrapper>
       <ChatWrapper ref={props.msgRef}>
-        {props.messages.map((el: any) => (
-          <>
+        {props.messages.map((el: any, idx: number) => (
+          <div key={el.key}>
+            {props.messages[idx - 1]?.id.slice(0, 15) !==
+              el.id.slice(0, 15) && <NewDate>{el.id.slice(0, 15)}</NewDate>}
             {props.myId !== el.writer[1] ? (
-              <GetMessageWrapper key={el.timestamp}>
+              <GetMessageWrapper>
                 <ProfileImg
                   src={el.profilePicUrl}
                   onClick={props.onClickToProfile}
@@ -46,20 +49,18 @@ export default function ChatRoomUI(props: any) {
                 </MessageInfo>
               </GetMessageWrapper>
             ) : (
-              <MyMessageWrapper key={el.timestamp}>
+              <MyMessageWrapper>
                 <GetMessageBox>{el.text}</GetMessageBox>
-                <MessageDate>{el.id}</MessageDate>
+                <MessageDate>{el.id.slice(16, 21)}</MessageDate>
               </MyMessageWrapper>
             )}
-          </>
+          </div>
         ))}
       </ChatWrapper>
       <ChatInputWrapper>
         <CommentsInputWrite
           placeholder="메세지를 입력하세요"
-          onChange={props.onChangemessage}
           ref={props.inputRef}
-          onKeyUp={props.enterKey}
         />
         <CommentsBnt onClick={props.saveMessage}>보내기</CommentsBnt>
       </ChatInputWrapper>

--- a/src/components/units/products/chatRoom/chatRoom.presenter.tsx
+++ b/src/components/units/products/chatRoom/chatRoom.presenter.tsx
@@ -59,6 +59,7 @@ export default function ChatRoomUI(props: any) {
           placeholder="메세지를 입력하세요"
           onChange={props.onChangemessage}
           ref={props.inputRef}
+          onKeyUp={props.enterKey}
         />
         <CommentsBnt onClick={props.saveMessage}>보내기</CommentsBnt>
       </ChatInputWrapper>

--- a/src/components/units/products/chatRoom/chatRoom.styles.ts
+++ b/src/components/units/products/chatRoom/chatRoom.styles.ts
@@ -99,3 +99,6 @@ export const MyMessageWrapper = styled.div`
   align-items: flex-end;
   padding-top: 5px;
 `;
+export const NewDate = styled.div`
+  text-align: center;
+`;


### PR DESCRIPTION
- 프로필이미지 클릭 -> 프로필페이지로
- 채팅 엔터이벤트 걸기 => 엔터 안하고 그냥 클릭하기… 엔터하면 중복으로 보내지는 문제 발생
- 채팅 시간 입력해주기(이전 날짜와 현재메세지 날짜 다를 때 날짜 넣어주기)
- 메세지 onChangeMessage에서 useRef로 한번에 보내는 것으로 변경 (메세지 입력 useRef 사용)